### PR TITLE
Add vault configuration to quick-start.

### DIFF
--- a/site/docs/get-started/quickstart.md
+++ b/site/docs/get-started/quickstart.md
@@ -14,10 +14,15 @@ Ensure that you have the following:
 ## Install cert-manager
 
 Mesh for Data requires [cert-manager](https://cert-manager.io) to be installed to your cluster. 
-Many clusters already include cert-manager. Run the following to install cert-manager only if it's missing:
+Many clusters already include cert-manager. Check if `cert-manager` namespace exists in your cluster and only run the following if it doesn't exist:
 
 ```bash
-kubectl get namespace cert-manager || kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
+helm install cert-manager jetstack/cert-manager \
+    --namespace cert-manager \
+    --version v1.2.0 \
+    --create-namespace \
+    --set installCRDs=true \
+    --wait --timeout 120s
 ``` 
 
 ## Install Hashicorp Vault and plugins

--- a/site/docs/get-started/quickstart.md
+++ b/site/docs/get-started/quickstart.md
@@ -49,8 +49,8 @@ Run the following to install vault and the plugin in development mode:
 
 ## Install control plane
 
-The control plane includes a `manager` service that connects to a data catalog and to a policy manger. 
-Install the latest release of Mesh for Data with a built-in data catalog and with [Open Policy Agent](https://www.openpolicyagent.org) as the policy manger:
+The control plane includes a `manager` service that connects to a data catalog and to a policy manager. 
+Install the latest release of Mesh for Data with a built-in data catalog and with [Open Policy Agent](https://www.openpolicyagent.org) as the policy manager:
 
 ```bash
 helm repo add m4d-charts https://mesh-for-data.github.io/charts

--- a/site/docs/get-started/quickstart.md
+++ b/site/docs/get-started/quickstart.md
@@ -1,0 +1,70 @@
+# Quick Start Guide
+
+Follow this guide to install Mesh for Data using default parameters that are suitable for experimentation.
+<!-- For a full installation refer to the [full installation guide](./setup/install) instead. -->
+
+## Before you begin
+
+Ensure that you have the following:
+
+- [Helm](https://helm.sh/) 3.3 or newer must be installed and configured on your machine.
+- [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) 1.16 or newer must be installed on your machine.
+- Access to a Kubernetes cluster such as [Kind](http://kind.sigs.k8s.io/) as a cluster administrator.
+
+## Install cert-manager
+
+Mesh for Data requires [cert-manager](https://cert-manager.io) to be installed to your cluster. 
+Many clusters already include cert-manager. Run the following to install cert-manager only if it's missing:
+
+```bash
+kubectl get namespace cert-manager || kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
+``` 
+
+## Install Hashicorp Vault and plugins
+
+[Hashicorp Vault](https://www.vaultproject.io/) and a [secrets-kubernetes-reader](https://github.com/mesh-for-data/vault-plugin-secrets-kubernetes-reader) plugin are used by Mesh for Data for credential management.
+
+Run the following to install vault and the plugin in development mode:
+
+=== "Kubernetes" 
+
+    ```bash
+    helm repo add hashicorp https://helm.releases.hashicorp.com
+    helm install vault hashicorp/vault --version 0.9.1 --create-namespace -n m4d-system \
+        --set "server.dev.enabled=true" \
+        --values https://raw.githubusercontent.com/IBM/the-mesh-for-data/master/third_party/vault/plugin-secrets-kubernetes-reader/values.yaml
+		--wait --timeout 120s
+    ```
+
+=== "OpenShift"
+
+    ```bash
+    helm repo add hashicorp https://helm.releases.hashicorp.com
+    helm install vault hashicorp/vault --version 0.9.1 --create-namespace -n m4d-system \
+        --set "global.openshift=true" \
+        --set "server.dev.enabled=true" \
+        --values https://raw.githubusercontent.com/IBM/the-mesh-for-data/master/third_party/vault/plugin-secrets-kubernetes-reader/values.yaml
+		--wait --timeout 120s
+    ```
+
+## Install control plane
+
+The control plane includes a `manager` service that connects to a data catalog and to a policy manger. 
+Install the latest release of Mesh for Data with a built-in data catalog and with [Open Policy Agent](https://www.openpolicyagent.org) as the policy manger:
+
+```bash
+helm repo add m4d-charts https://mesh-for-data.github.io/charts
+helm install m4d-crd m4d-charts/m4d-crd -n m4d-system --wait
+helm install m4d m4d-charts/m4d -n m4d-system --wait
+```
+
+
+## Install modules
+
+[Modules](../concepts/modules.md) are plugins that the control plane deploys whenever required. 
+
+Install the [arrow flight module](https://github.com/ibm/the-mesh-for-data-flight-module):
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/IBM/the-mesh-for-data-flight-module/master/module.yaml
+```

--- a/site/docs/get-started/quickstart.md
+++ b/site/docs/get-started/quickstart.md
@@ -32,8 +32,8 @@ Run the following to install vault and the plugin in development mode:
     helm repo add hashicorp https://helm.releases.hashicorp.com
     helm install vault hashicorp/vault --version 0.9.1 --create-namespace -n m4d-system \
         --set "server.dev.enabled=true" \
-        --values https://raw.githubusercontent.com/IBM/the-mesh-for-data/master/third_party/vault/plugin-secrets-kubernetes-reader/values.yaml
-		--wait --timeout 120s
+        --values https://raw.githubusercontent.com/IBM/the-mesh-for-data/master/third_party/vault/plugin-secrets-kubernetes-reader/values.yaml \
+        --wait --timeout 120s
     ```
 
 === "OpenShift"
@@ -43,8 +43,8 @@ Run the following to install vault and the plugin in development mode:
     helm install vault hashicorp/vault --version 0.9.1 --create-namespace -n m4d-system \
         --set "global.openshift=true" \
         --set "server.dev.enabled=true" \
-        --values https://raw.githubusercontent.com/IBM/the-mesh-for-data/master/third_party/vault/plugin-secrets-kubernetes-reader/values.yaml
-		--wait --timeout 120s
+        --values https://raw.githubusercontent.com/IBM/the-mesh-for-data/master/third_party/vault/plugin-secrets-kubernetes-reader/values.yaml \
+        --wait --timeout 120s
     ```
 
 ## Install control plane

--- a/site/docs/get-started/quickstart.md
+++ b/site/docs/get-started/quickstart.md
@@ -34,21 +34,27 @@ Run the following to install vault and the plugin in development mode:
 === "Kubernetes" 
 
     ```bash
+    kubectl create namespace m4d-system || true
+    kubectl apply -f https://raw.githubusercontent.com/IBM/the-mesh-for-data/master/third_party/vault/vault-single-cluster/vault-rbac.yaml -n m4d-system
     helm repo add hashicorp https://helm.releases.hashicorp.com
-    helm install vault hashicorp/vault --version 0.9.1 --create-namespace -n m4d-system \
+    helm install vault hashicorp/vault --version 0.9.1 \
         --set "server.dev.enabled=true" \
-        --values https://raw.githubusercontent.com/IBM/the-mesh-for-data/master/third_party/vault/plugin-secrets-kubernetes-reader/values.yaml \
+        --values https://raw.githubusercontent.com/IBM/the-mesh-for-data/master/third_party/vault/vault-single-cluster/values.yaml \
+        --namespace m4d-system \
         --wait --timeout 120s
     ```
 
 === "OpenShift"
 
     ```bash
+    kubectl create namespace m4d-system || true
+    kubectl apply -f https://raw.githubusercontent.com/IBM/the-mesh-for-data/master/third_party/vault/vault-single-cluster/vault-rbac.yaml -n m4d-system
     helm repo add hashicorp https://helm.releases.hashicorp.com
-    helm install vault hashicorp/vault --version 0.9.1 --create-namespace -n m4d-system \
+    helm install vault hashicorp/vault --version 0.9.1 \
         --set "global.openshift=true" \
         --set "server.dev.enabled=true" \
-        --values https://raw.githubusercontent.com/IBM/the-mesh-for-data/master/third_party/vault/plugin-secrets-kubernetes-reader/values.yaml \
+        --values https://raw.githubusercontent.com/IBM/the-mesh-for-data/master/third_party/vault/vault-single-cluster/values.yaml \
+        --namespace m4d-system \
         --wait --timeout 120s
     ```
 

--- a/third_party/vault/vault-single-cluster/values.yaml
+++ b/third_party/vault/vault-single-cluster/values.yaml
@@ -1,0 +1,54 @@
+server:
+  extraArgs: '-dev-plugin-dir=/usr/local/libexec/vault'
+  volumes:
+    - name: plugins
+      emptyDir: {}
+  volumeMounts:
+    - mountPath: /usr/local/libexec/vault
+      name: plugins
+      readOnly: false
+  extraInitContainers:
+    - name: kubesecrets-plugin
+      image: ghcr.io/revit13/vault-plugin-secrets-kubernetes-reader:latest
+      command: [/bin/sh, -ec]
+      args:
+        - cp /vault-plugin-secrets-kubernetes-reader /usr/local/libexec/vault/vault-plugin-secrets-kubernetes-reader
+      volumeMounts:
+      - name: plugins
+        mountPath: /usr/local/libexec/vault
+        readOnly: false
+  extraEnvironmentVars:
+    VAULT_API_ADDR: http://127.0.0.1:8200
+    VAULT_ADDR: http://127.0.0.1:8200
+  # Used to define commands to run after the pod is ready.
+  # This can be used to automate processes such as initialization
+  # or boostrapping auth methods.
+  postStart:
+    - "sh"
+    - "-c"
+    # Sleep command is needed to avoid synchronization issues with the container pod. Please see
+    # https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#discussion
+    # FIXME: Use a proper way to configure Vault after Vault start-up
+    - | 
+      sleep 5
+      # configuring kubernetes auth method and use it later to create roles.
+      vault auth enable kubernetes
+      vault write auth/kubernetes/config kubernetes_host="https://kubernetes.default.svc:443"
+      # enable secret engine
+      vault secrets enable -path=kubernetes-secrets vault-plugin-secrets-kubernetes-reader
+      # create policy to access secrets
+      # NOTE: m4d/dataset-creds/ secret engine is enabled by the manager and is used temporarily
+      # to store dataset credentials.
+      vault policy write "allow-all-dataset-creds" - <<EOF
+      path "m4d/dataset-creds/*" {
+      capabilities = ["create", "read", "update", "delete", "list"]
+      }
+      path "kubernetes-secrets/*" {
+      capabilities = ["create", "read", "update", "delete", "list"]
+      }
+      EOF
+      # allow modules running in m4d-blueprints namespace to access dataset credentials
+      vault write auth/kubernetes/role/module bound_service_account_names="*" bound_service_account_namespaces="m4d-blueprints" policies="allow-all-dataset-creds" ttl=24h
+      # enable userpass auth method
+      vault auth enable userpass
+      vault write auth/userpass/users/data_provider password=password policies="allow-all-dataset-creds" 

--- a/third_party/vault/vault-single-cluster/vault-rbac.yaml
+++ b/third_party/vault/vault-single-cluster/vault-rbac.yaml
@@ -1,0 +1,70 @@
+# Copyright 2020 IBM Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-auth
+  namespace: m4d-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-auth
+  namespace: m4d-system
+  annotations:
+    kubernetes.io/service-account.name: vault-auth
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: role-tokenreview-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: vault-auth
+    namespace: m4d-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vault-secrets-manager
+rules:
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["get"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vault
+subjects:
+- kind: ServiceAccount
+  name: vault
+  namespace: m4d-system
+roleRef:
+  kind: ClusterRole
+  name: vault-secrets-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+# This binding allows the deployed Vault instance to authenticate clients
+# through Kubernetes ServiceAccounts (if configured so).
+# NOTE: to be removed with secret-provider code.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: vault
+    namespace: m4d-system
+


### PR DESCRIPTION
This PR adds the following Vault configuration to the quick-start:

1) it configures Kubernetes auth method in path called kubernetes: this auth path is used later to add roles for the modules and secret provider.
2) it enables Kubernetes secret plugin reader
3) it creates a policy to access secrets
4) it creates a role to bind modules running in m4d-blueprint namespace to use the policy above.
5) it creates userpass auth method.

This configuration completes the existing Vault configuration done in the manager:
1) it mounts secret engine for dataset credentials
2) it adds a policy to access it
3) it adds a role in kubernetes auth path for the secret provider to use the policy above

